### PR TITLE
Anisha

### DIFF
--- a/client/src/containers/liveChat/live.js
+++ b/client/src/containers/liveChat/live.js
@@ -160,7 +160,7 @@ class LiveChat extends React.Component {
     this.props.fetchUserChats(session._id, {page: 'first', number: 25})
     console.log('session in changeActiveSession', session)
     this.props.markRead(session._id)
-    this.props.getSubscriberTags(session.subscriber_id, this.msg)
+    this.props.getSubscriberTags(session.subscriber_id._id, this.msg)
   }
 
   handleSearch (e) {

--- a/client/src/redux/actions/tags.actions.js
+++ b/client/src/redux/actions/tags.actions.js
@@ -82,7 +82,7 @@ export function createTag (tag, handleResponse, msg) {
 export function getSubscriberTags (id, msg) {
   console.log('Actions for getting subscriber Tag', id)
   return (dispatch) => {
-    callApi('tags/subscribertags/', 'post', {subscriberId: id._id})
+    callApi('tags/subscribertags/', 'post', {subscriberId: id})
       .then(res => {
         if (res.status === 'success' && res.payload) {
           dispatch(loadSubscriberTags(res.payload))


### PR DESCRIPTION
#4469 
https://github.com/Cloudkibo/KiboPush/issues/5015
This issue occurred because getSubcriberTags function was being called from several places. And in one place, it was sending whole subscriber object instead of just the subscriber id.
https://github.com/Cloudkibo/KiboPush/commit/7f679aba26595530b2a17441bd14d45210eeb675#diff-cbd672f74453d2fc0d9eaec0583a8bdf